### PR TITLE
add errors prompt

### DIFF
--- a/CPP/7zip/UI/Console/MainAr.cpp
+++ b/CPP/7zip/UI/Console/MainAr.cpp
@@ -100,7 +100,12 @@ int MY_CDECL main
     }
     if (g_ErrStream)
     {
-      PrintError("System ERROR:");
+#ifdef __linux__
+      FlushStreams();
+      *g_ErrStream << "\n\n" << "System ERROR:" << errno << endl; // 输出系统错误码，方便解析错误类型
+#else
+      PrintError("System ERROR:");	      PrintError("System ERROR:");
+#endif
       *g_ErrStream << NError::MyFormatMessage(systemError.ErrorCode) << endl;
     }
     return (NExitCode::kFatalError);


### PR DESCRIPTION
Some errors in Linux are not clear, such as insufficient disk space when compressing, only prompt E_ Fail, it's not clear what kind of error it is